### PR TITLE
Swap back to LlamaCpp because we are out of VRAM to run vLLM

### DIFF
--- a/llm/equipo_llm.py
+++ b/llm/equipo_llm.py
@@ -1,18 +1,28 @@
-from langchain.llms import VLLM
+from langchain.llms import VLLM, LlamaCpp
 from langchain.prompts.chat import ChatPromptTemplate
+from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from pydantic import BaseModel
 import re
 
-model_path = "CalvinU/Llama-2-7b-chat-hf-awq"
+# model_path = "CalvinU/Llama-2-7b-chat-hf-awq"
 
-# Instantiate the VLLM model for inference
-llm = VLLM(
-    model=model_path,
-    trust_remote_code=True,
-    max_new_tokens=128,
-    top_k=10,
-    top_p=0.95,
-    temperature=0.8,
+# # Instantiate the VLLM model for inference
+# llm = VLLM(
+#     model=model_path,
+#     trust_remote_code=True,
+#     max_new_tokens=128,
+#     top_k=10,
+#     top_p=0.95,
+#     temperature=0.8,
+# )
+
+model_path = "/home/jk249/service/Llama-2-7b-chat-hf/llama-2-7b-chat-hf.gguf.q4_k_m.bin"
+
+llm = LlamaCpp(
+    model_path=model_path,
+    temperature=1,
+    callbacks=[StreamingStdOutCallbackHandler()],
+    verbose=False,
 )
 
 # Topic generation template


### PR DESCRIPTION
Sadly our private server does not have enough VRAM to support AutoAWQ quantized model running on the GPU. Hopefully this could be configured in the far future. Swap back to LlamaCpp (CPU inference) for now...